### PR TITLE
fix: use terraform output IDs for tool naming in E2E tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,10 +67,12 @@ jobs:
         run: |
           GATEWAY_URL="${{ needs.terraform_deploy.outputs.gateway_url }}"
           PROJECT_NAME="${{ needs.terraform_deploy.outputs.project_name }}"
+          GATEWAY_ID="${{ needs.terraform_deploy.outputs.gateway_id }}"
+          TARGET_ID="${{ needs.terraform_deploy.outputs.target_id }}"
           TOKEN="${{ steps.get-token.outputs.token }}"
           
           # Tool naming: {gateway-id}_{target-id}___tool-name
-          TOOL_NAME="${PROJECT_NAME}_${PROJECT_NAME}-target___get_weather"
+          TOOL_NAME="${GATEWAY_ID}_${TARGET_ID}___get_weather"
           
           echo "Testing weather tool via AgentCore Gateway..."
           echo "Tool name: $TOOL_NAME"

--- a/.github/workflows/pr-environment.yml
+++ b/.github/workflows/pr-environment.yml
@@ -99,10 +99,12 @@ jobs:
         run: |
           GATEWAY_URL="${{ needs.terraform_apply_pr.outputs.gateway_url }}"
           PROJECT_NAME="${{ needs.terraform_apply_pr.outputs.project_name }}"
+          GATEWAY_ID="${{ needs.terraform_apply_pr.outputs.gateway_id }}"
+          TARGET_ID="${{ needs.terraform_apply_pr.outputs.target_id }}"
           TOKEN="${{ steps.get-token.outputs.token }}"
           
           # Tool naming: {gateway-id}_{target-id}___tool-name
-          TOOL_NAME="${PROJECT_NAME}_${PROJECT_NAME}-target___get_weather"
+          TOOL_NAME="${GATEWAY_ID}_${TARGET_ID}___get_weather"
           
           echo "Testing weather tool via AgentCore Gateway..."
           echo "Tool name: $TOOL_NAME"

--- a/.github/workflows/reusable-terraform.yml
+++ b/.github/workflows/reusable-terraform.yml
@@ -41,6 +41,12 @@ on:
       scope:
         description: 'Entra app scope'
         value: ${{ jobs.terraform.outputs.scope }}
+      gateway_id:
+        description: 'AgentCore Gateway ID'
+        value: ${{ jobs.terraform.outputs.gateway_id }}
+      target_id:
+        description: 'AgentCore Gateway Target ID'
+        value: ${{ jobs.terraform.outputs.target_id }}
 
 permissions:
   id-token: write
@@ -56,6 +62,8 @@ jobs:
       project_name: ${{ steps.terraform-outputs.outputs.project_name }}
       client_id: ${{ steps.terraform-outputs.outputs.client_id }}
       scope: ${{ steps.terraform-outputs.outputs.scope }}
+      gateway_id: ${{ steps.terraform-outputs.outputs.gateway_id }}
+      target_id: ${{ steps.terraform-outputs.outputs.target_id }}
     steps:
       - name: 📦 Checkout code
         uses: actions/checkout@v5
@@ -168,3 +176,5 @@ jobs:
           echo "project_name=$(terraform output -raw project_name 2>/dev/null || echo "")" >> $GITHUB_OUTPUT
           echo "client_id=$(terraform output -raw entra_app_client_id 2>/dev/null || echo "")" >> $GITHUB_OUTPUT
           echo "scope=$(terraform output -raw entra_app_scope_client_credentials 2>/dev/null || echo "")" >> $GITHUB_OUTPUT
+          echo "gateway_id=$(terraform output -raw agentcore_gateway_id 2>/dev/null || echo "")" >> $GITHUB_OUTPUT
+          echo "target_id=$(terraform output -raw agentcore_gateway_target_id 2>/dev/null || echo "")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Update `.github/workflows/reusable-terraform.yml` to output `agentcore_gateway_id` and `agentcore_gateway_target_id`.
- Update `.github/workflows/pr-environment.yml` and `.github/workflows/deploy.yml` to use these IDs for constructing the tool name in E2E tests.
- Fixes E2E test failure where tool name was incorrectly constructed using the project name instead of the actual resource IDs.

## References
- [Amazon Bedrock AgentCore Gateway Tool Naming](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-tool-naming.html)