### PR TITLE
fix: install clippy and rustfmt in brown-ninja-bot workflow

### DIFF
--- a/.github/workflows/brown-ninja-bot.yml
+++ b/.github/workflows/brown-ninja-bot.yml
@@ -44,7 +44,7 @@ jobs:
         id: rust-toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          components: rust-src
+          components: rust-src, clippy, rustfmt
           targets: aarch64-unknown-linux-gnu
 
       - name: 💾 Cache Rust dependencies


### PR DESCRIPTION
## Summary
- Add `clippy` and `rustfmt` to the rust toolchain components in `brown-ninja-bot.yml`.
- Ensures the bot has the necessary tools to lint and format code as per the prompt instructions.