### PR TITLE
fix: make brown-ninja-bot robust by forcing branch creation and push

### DIFF
--- a/.github/workflows/brown-ninja-bot.yml
+++ b/.github/workflows/brown-ninja-bot.yml
@@ -137,7 +137,7 @@ jobs:
           fi
 
           BRANCH="fix/issue-${ISSUE_NUM:-workflow-failure}"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
 
           PROMPT="You are the best developer humanity has ever seen. Fix this issue completely:
 
@@ -178,7 +178,7 @@ jobs:
 
           $(cat fix_output.txt | head -20)"
 
-          git push -u origin "$BRANCH"
+          git push -f -u origin "$BRANCH"
 
           PR_URL=$(gh pr create \
             --title "🥷 Fix: $ISSUE_TITLE" \


### PR DESCRIPTION
## Summary
- Update `brown-ninja-bot.yml` to use `git checkout -B` (force branch creation/reset) and `git push -f` (force push).
- This ensures that the bot can recover from previous failed runs where the branch might already exist locally or remotely, allowing it to overwrite with a fresh fix attempt.

## Motivation
- If the bot workflow fails after creating a branch (e.g. at PR creation step), the branch is not cleaned up. Subsequent runs would fail without these changes.